### PR TITLE
Fix syntax error

### DIFF
--- a/services/sync-roles-permissions.js
+++ b/services/sync-roles-permissions.js
@@ -56,7 +56,7 @@ module.exports = {
     if (!isValidJSON) {
       const errorMessage = "Please provide a valid JSON";
       if (ctx) {
-        return ctx?.throw(400, errorMessage);
+        return ctx.throw(400, errorMessage);
       }
 
       throw new Error(errorMessage);


### PR DESCRIPTION
It produced this error:

```
strapi_1  | [2021-04-24T22:06:46.103Z] debug ⛔️ Server wasn't able to start properly.
strapi_1  | [2021-04-24T22:06:46.105Z] error /srv/app/node_modules/strapi-plugin-sync-roles-permissions/services/sync-roles-permissions.js:59
strapi_1  |         return ctx?.throw(400, errorMessage);
strapi_1  |                    ^
strapi_1  | 
strapi_1  | SyntaxError: Unexpected token '.'
strapi_1  |     at wrapSafe (internal/modules/cjs/loader.js:915:16)
strapi_1  |     at Module._compile (internal/modules/cjs/loader.js:963:27)
strapi_1  |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
strapi_1  |     at Module.load (internal/modules/cjs/loader.js:863:32)
strapi_1  |     at Function.Module._load (internal/modules/cjs/loader.js:708:14)
strapi_1  |     at Module.require (internal/modules/cjs/loader.js:887:19)
strapi_1  |     at require (internal/modules/cjs/helpers.js:74:18)
strapi_1  |     at loadFiles (/srv/app/node_modules/strapi/lib/load/load-files.js:37:13)
strapi_1  |     at async loadPlugins (/srv/app/node_modules/strapi/lib/core/load-plugins.js:53:19)
strapi_1  |     at async module.exports (/srv/app/node_modules/strapi/lib/core/load-plugins.js:12:19)
```